### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ghpages.yml
+++ b/.github/workflows/ghpages.yml
@@ -13,6 +13,8 @@ concurrency: # Ensure only one workflow is running at a time
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/CyberCup/2025.cybercup.it/security/code-scanning/1](https://github.com/CyberCup/2025.cybercup.it/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the `build` job. Since the `build` job primarily involves checking out the repository, installing dependencies, and building the project, it only requires `contents: read` permissions. This change will explicitly limit the `GITHUB_TOKEN` permissions for the `build` job, ensuring it has only the access it needs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
